### PR TITLE
Sample networks should support v0.11.x and v0.12.x

### DIFF
--- a/packages/animaltracking-network/package.json
+++ b/packages/animaltracking-network/package.json
@@ -1,6 +1,6 @@
 {
   "engines": {
-    "composer": "^0.11.0"
+    "composer": "^0.11.0 || ^0.12.0"
   },
   "name": "animaltracking-network",
   "version": "0.1.7",

--- a/packages/basic-sample-network/package.json
+++ b/packages/basic-sample-network/package.json
@@ -1,6 +1,6 @@
 {
   "engines": {
-    "composer": "^0.11.0"
+    "composer": "^0.11.0 || ^0.12.0"
   },
   "name": "basic-sample-network",
   "version": "0.1.7",

--- a/packages/bond-network/package.json
+++ b/packages/bond-network/package.json
@@ -1,6 +1,6 @@
 {
   "engines": {
-    "composer": "^0.11.0"
+    "composer": "^0.11.0 || ^0.12.0"
   },
   "name": "bond-network",
   "version": "0.1.7",

--- a/packages/carauction-network/package.json
+++ b/packages/carauction-network/package.json
@@ -1,6 +1,6 @@
 {
   "engines": {
-    "composer": "^0.11.0"
+    "composer": "^0.11.0 || ^0.12.0"
   },
   "name": "carauction-network",
   "version": "0.1.7",

--- a/packages/digitalproperty-network/package.json
+++ b/packages/digitalproperty-network/package.json
@@ -1,6 +1,6 @@
 {
   "engines": {
-    "composer": "^0.11.0"
+    "composer": "^0.11.0 || ^0.12.0"
   },
   "name": "digitalproperty-network",
   "version": "0.1.7",

--- a/packages/marbles-network/package.json
+++ b/packages/marbles-network/package.json
@@ -1,6 +1,6 @@
 {
   "engines": {
-    "composer": "^0.11.0"
+    "composer": "^0.11.0 || ^0.12.0"
   },
   "name": "marbles-network",
   "version": "0.1.7",

--- a/packages/perishable-network/package.json
+++ b/packages/perishable-network/package.json
@@ -1,6 +1,6 @@
 {
   "engines": {
-    "composer": "^0.11.0"
+    "composer": "^0.11.0 || ^0.12.0"
   },
   "name": "perishable-network",
   "version": "0.1.7",

--- a/packages/pii-network/package.json
+++ b/packages/pii-network/package.json
@@ -1,6 +1,6 @@
 {
   "engines": {
-    "composer": "^0.11.0"
+    "composer": "^0.11.0 || ^0.12.0"
   },
   "name": "pii-network",
   "version": "0.1.7",

--- a/packages/trade-network/package.json
+++ b/packages/trade-network/package.json
@@ -1,6 +1,6 @@
 {
   "engines": {
-    "composer": "^0.11.0"
+    "composer": "^0.11.0 || ^0.12.0"
   },
   "name": "trade-network",
   "version": "0.1.7",

--- a/packages/vehicle-lifecycle-network/package.json
+++ b/packages/vehicle-lifecycle-network/package.json
@@ -1,6 +1,6 @@
 {
   "engines": {
-    "composer": "^0.11.0"
+    "composer": "^0.11.0 || ^0.12.0"
   },
   "name": "vehicle-lifecycle-network",
   "version": "0.1.7",


### PR DESCRIPTION
We are bumping the version number to v0.12.0, unfortunately there are no sample networks that support this level yet and so we must update the sample networks first!

Remove specialised historian registry type #1924