### PR TITLE
fix of issue #1500 along with review comments

### DIFF
--- a/packages/vehicle-lifecycle-network/lib/vda.js
+++ b/packages/vehicle-lifecycle-network/lib/vda.js
@@ -108,5 +108,6 @@ function scrapAllVehiclesByColour(scrapAllVehicles) {
                  return assetRegistry.updateAll(vehiclesToScrap);
              }
         });
+
 }
 

--- a/packages/vehicle-lifecycle-network/queries.qry
+++ b/packages/vehicle-lifecycle-network/queries.qry
@@ -1,0 +1,6 @@
+query selectAllCarsByColour {
+  description: "Select all cars based on their colour"
+  statement:
+      SELECT org.vda.Vehicle
+          WHERE (vehicleDetails.colour==_$colour)
+}

--- a/packages/vehicle-lifecycle-network/queries.qry
+++ b/packages/vehicle-lifecycle-network/queries.qry
@@ -4,3 +4,4 @@ query selectAllCarsByColour {
       SELECT org.vda.Vehicle
           WHERE (vehicleDetails.colour==_$colour)
 }
+

--- a/packages/vehicle-lifecycle-network/test/vda.js
+++ b/packages/vehicle-lifecycle-network/test/vda.js
@@ -36,7 +36,7 @@ describe('Vehicle Lifecycle Network', function() {
 
     var businessNetworkConnection;
 
-    before(function() {
+    beforeEach(function() {
         BrowserFS.initialize(new BrowserFS.FileSystem.InMemory());
         var adminConnection = new AdminConnection({ fs: bfs_fs });
         return adminConnection.createProfile('defaultProfile', {
@@ -124,4 +124,30 @@ describe('Vehicle Lifecycle Network', function() {
                 });
         });
     });
+
+    describe('ScrapAllVehiclesByColour', function() {
+        it('should select vehicles by colour and change vehicles status to SCRAPPED', function() {
+            /* vehicle with beige colour
+               and id 123456789 resides
+               in reposritory
+            */
+            var vehicleId = '123456789';
+            var scrapVehicleTransaction = factory.newTransaction(NS_D, 'ScrapAllVehiclesByColour');
+            scrapVehicleTransaction.colour = 'Beige';
+            return businessNetworkConnection.submitTransaction(scrapVehicleTransaction)
+                .then(function() {
+                    return businessNetworkConnection.getAssetRegistry(NS_D + '.Vehicle');
+                })
+                .then(function(ar) {
+                    var assetRegistry = ar;
+                    return assetRegistry.get(vehicleId);
+                })
+                .then(function(vehicle) {
+                    vehicle.vehicleStatus.should.equal('SCRAPPED');
+                });
+
+        });
+    });
+
+
 });

--- a/packages/vehicle-lifecycle-network/test/vda.js
+++ b/packages/vehicle-lifecycle-network/test/vda.js
@@ -149,5 +149,4 @@ describe('Vehicle Lifecycle Network', function() {
         });
     });
 
-
 });


### PR DESCRIPTION
Problem
The issue #1500 deals with the fact that a query in vehicle lifecycle network is not running.

Solution
The query Native is not supported now. The feature of Named Query has been implemented instead. The same is added here in.

TestCase
A new testcase has been added to check the functionality of queryNative. The test case select all vehicles by colour (in the test case colour = "Beige") and selected vehicle status is marked "scrapped"        