### PR TITLE
Add network admin ACL rules, bump Composer version to 0.14.0

### DIFF
--- a/packages/animaltracking-network/package.json
+++ b/packages/animaltracking-network/package.json
@@ -1,6 +1,6 @@
 {
   "engines": {
-    "composer": "^0.11.0 || ^0.12.0 || ^0.13.0"
+    "composer": "^0.14.0"
   },
   "name": "animaltracking-network",
   "version": "0.1.10",
@@ -36,8 +36,8 @@
   "devDependencies": {
     "browserfs": "^1.2.0",
     "chai": "^3.5.0",
-    "composer-cli": "^0.11.0",
-    "composer-connector-embedded": "^0.11.0",
+    "composer-cli": "^0.14.0-0",
+    "composer-connector-embedded": "^0.14.0-0",
     "eslint": "^3.6.1",
     "jsdoc": "^3.4.1",
     "license-check": "^1.1.5",

--- a/packages/animaltracking-network/permissions.acl
+++ b/packages/animaltracking-network/permissions.acl
@@ -16,3 +16,19 @@ rule SystemACL {
   resource: "org.hyperledger.composer.system.**"
   action: ALLOW
 }
+
+rule NetworkAdminUser {
+    description: "Grant business network administrators full access to user resources"
+    participant: "org.hyperledger.composer.system.NetworkAdmin"
+    operation: ALL
+    resource: "**"
+    action: ALLOW
+}
+
+rule NetworkAdminSystem {
+    description: "Grant business network administrators full access to system resources"
+    participant: "org.hyperledger.composer.system.NetworkAdmin"
+    operation: ALL
+    resource: "org.hyperledger.composer.system.**"
+    action: ALLOW
+}

--- a/packages/basic-sample-network/package.json
+++ b/packages/basic-sample-network/package.json
@@ -1,6 +1,6 @@
 {
   "engines": {
-    "composer": "^0.11.0 || ^0.12.0 || ^0.13.0"
+    "composer": "^0.14.0"
   },
   "name": "basic-sample-network",
   "version": "0.1.10",
@@ -34,11 +34,11 @@
     "browserfs": "^1.2.0",
     "chai": "^3.5.0",
     "chai-as-promised": "^6.0.0",
-    "composer-admin": "^0.11.0",
-    "composer-cli": "^0.11.0",
-    "composer-client": "^0.11.0",
-    "composer-connector-embedded": "^0.11.0",
-    "composer-cucumber-steps": "^0.11.0",
+    "composer-admin": "^0.14.0-0",
+    "composer-cli": "^0.14.0-0",
+    "composer-client": "^0.14.0-0",
+    "composer-connector-embedded": "^0.14.0-0",
+    "composer-cucumber-steps": "^0.14.0-0",
     "cucumber": "^2.2.0",
     "eslint": "^3.6.1",
     "istanbul": "^0.4.5",

--- a/packages/basic-sample-network/permissions.acl
+++ b/packages/basic-sample-network/permissions.acl
@@ -33,3 +33,19 @@ rule SystemACL {
   resource: "org.hyperledger.composer.system.**"
   action: ALLOW
 }
+
+rule NetworkAdminUser {
+    description: "Grant business network administrators full access to user resources"
+    participant: "org.hyperledger.composer.system.NetworkAdmin"
+    operation: ALL
+    resource: "**"
+    action: ALLOW
+}
+
+rule NetworkAdminSystem {
+    description: "Grant business network administrators full access to system resources"
+    participant: "org.hyperledger.composer.system.NetworkAdmin"
+    operation: ALL
+    resource: "org.hyperledger.composer.system.**"
+    action: ALLOW
+}

--- a/packages/bond-network/package.json
+++ b/packages/bond-network/package.json
@@ -1,6 +1,6 @@
 {
   "engines": {
-    "composer": "^0.11.0 || ^0.12.0  || ^0.13.0"
+    "composer": "^0.14.0"
   },
   "name": "bond-network",
   "version": "0.1.10",
@@ -34,10 +34,10 @@
   "devDependencies": {
     "browserfs": "^1.2.0",
     "chai": "^3.5.0",
-    "composer-admin": "^0.11.0",
-    "composer-cli": "^0.11.0",
-    "composer-client": "^0.11.0",
-    "composer-connector-embedded": "^0.11.0",
+    "composer-admin": "^0.14.0-0",
+    "composer-cli": "^0.14.0-0",
+    "composer-client": "^0.14.0-0",
+    "composer-connector-embedded": "^0.14.0-0",
     "eslint": "^3.6.1",
     "istanbul": "^0.4.5",
     "jsdoc": "^3.4.1",

--- a/packages/bond-network/permissions.acl
+++ b/packages/bond-network/permissions.acl
@@ -6,7 +6,7 @@ rule Issuer {
     participant(i): "org.acme.bond.Issuer"
     operation: ALL
     resource(a): "org.acme.bond.BondAsset"
-    condition: (a.bond.issuer.memberId === i.memberId) 
+    condition: (a.bond.issuer.memberId === i.memberId)
     action: ALLOW
 }
 
@@ -24,4 +24,20 @@ rule SystemACL {
   operation: ALL
   resource: "org.hyperledger.composer.system.**"
   action: ALLOW
+}
+
+rule NetworkAdminUser {
+    description: "Grant business network administrators full access to user resources"
+    participant: "org.hyperledger.composer.system.NetworkAdmin"
+    operation: ALL
+    resource: "**"
+    action: ALLOW
+}
+
+rule NetworkAdminSystem {
+    description: "Grant business network administrators full access to system resources"
+    participant: "org.hyperledger.composer.system.NetworkAdmin"
+    operation: ALL
+    resource: "org.hyperledger.composer.system.**"
+    action: ALLOW
 }

--- a/packages/carauction-network/package.json
+++ b/packages/carauction-network/package.json
@@ -1,6 +1,6 @@
 {
   "engines": {
-    "composer": "^0.11.0 || ^0.12.0 || ^0.13.0"
+    "composer": "^0.14.0"
   },
   "name": "carauction-network",
   "version": "0.1.10",
@@ -33,10 +33,10 @@
   "devDependencies": {
     "browserfs": "^1.2.0",
     "chai": "^3.5.0",
-    "composer-admin": "^0.11.0",
-    "composer-cli": "^0.11.0",
-    "composer-client": "^0.11.0",
-    "composer-connector-embedded": "^0.11.0",
+    "composer-admin": "^0.14.0-0",
+    "composer-cli": "^0.14.0-0",
+    "composer-client": "^0.14.0-0",
+    "composer-connector-embedded": "^0.14.0-0",
     "eslint": "^3.6.1",
     "istanbul": "^0.4.5",
     "jsdoc": "^3.4.1",

--- a/packages/carauction-network/permissions.acl
+++ b/packages/carauction-network/permissions.acl
@@ -40,5 +40,21 @@ rule SystemACL {
   participant: "org.hyperledger.composer.system.Participant"
   operation: ALL
   resource: "org.hyperledger.composer.system.**"
-  action: ALLOW  
+  action: ALLOW
+}
+
+rule NetworkAdminUser {
+    description: "Grant business network administrators full access to user resources"
+    participant: "org.hyperledger.composer.system.NetworkAdmin"
+    operation: ALL
+    resource: "**"
+    action: ALLOW
+}
+
+rule NetworkAdminSystem {
+    description: "Grant business network administrators full access to system resources"
+    participant: "org.hyperledger.composer.system.NetworkAdmin"
+    operation: ALL
+    resource: "org.hyperledger.composer.system.**"
+    action: ALLOW
 }

--- a/packages/digitalproperty-network/package.json
+++ b/packages/digitalproperty-network/package.json
@@ -1,6 +1,6 @@
 {
   "engines": {
-    "composer": "^0.11.0 || ^0.12.0  || ^0.13.0"
+    "composer": "^0.14.0"
   },
   "name": "digitalproperty-network",
   "version": "0.1.10",
@@ -32,10 +32,10 @@
   "devDependencies": {
     "browserfs": "^1.2.0",
     "chai": "^3.5.0",
-    "composer-admin": "^0.11.0",
-    "composer-cli": "^0.11.0",
-    "composer-client": "^0.11.0",
-    "composer-connector-embedded": "^0.11.0",
+    "composer-admin": "^0.14.0-0",
+    "composer-cli": "^0.14.0-0",
+    "composer-client": "^0.14.0-0",
+    "composer-connector-embedded": "^0.14.0-0",
     "eslint": "^3.6.1",
     "istanbul": "^0.4.5",
     "jsdoc": "^3.4.1",

--- a/packages/digitalproperty-network/permissions.acl
+++ b/packages/digitalproperty-network/permissions.acl
@@ -16,3 +16,19 @@ rule SystemACL {
   resource: "org.hyperledger.composer.system.**"
   action: ALLOW
 }
+
+rule NetworkAdminUser {
+    description: "Grant business network administrators full access to user resources"
+    participant: "org.hyperledger.composer.system.NetworkAdmin"
+    operation: ALL
+    resource: "**"
+    action: ALLOW
+}
+
+rule NetworkAdminSystem {
+    description: "Grant business network administrators full access to system resources"
+    participant: "org.hyperledger.composer.system.NetworkAdmin"
+    operation: ALL
+    resource: "org.hyperledger.composer.system.**"
+    action: ALLOW
+}

--- a/packages/marbles-network/package.json
+++ b/packages/marbles-network/package.json
@@ -1,6 +1,6 @@
 {
   "engines": {
-    "composer": "^0.11.0 || ^0.12.0  || ^0.13.0"
+    "composer": "^0.14.0"
   },
   "name": "marbles-network",
   "version": "0.1.10",
@@ -33,10 +33,10 @@
   "devDependencies": {
     "browserfs": "^1.2.0",
     "chai": "^3.5.0",
-    "composer-admin": "^0.11.0",
-    "composer-cli": "^0.11.0",
-    "composer-client": "^0.11.0",
-    "composer-connector-embedded": "^0.11.0",
+    "composer-admin": "^0.14.0-0",
+    "composer-cli": "^0.14.0-0",
+    "composer-client": "^0.14.0-0",
+    "composer-connector-embedded": "^0.14.0-0",
     "eslint": "^3.6.1",
     "istanbul": "^0.4.5",
     "jsdoc": "^3.4.1",

--- a/packages/marbles-network/permissions.acl
+++ b/packages/marbles-network/permissions.acl
@@ -16,3 +16,19 @@ rule SystemACL {
   resource: "org.hyperledger.composer.system.**"
   action: ALLOW
 }
+
+rule NetworkAdminUser {
+    description: "Grant business network administrators full access to user resources"
+    participant: "org.hyperledger.composer.system.NetworkAdmin"
+    operation: ALL
+    resource: "**"
+    action: ALLOW
+}
+
+rule NetworkAdminSystem {
+    description: "Grant business network administrators full access to system resources"
+    participant: "org.hyperledger.composer.system.NetworkAdmin"
+    operation: ALL
+    resource: "org.hyperledger.composer.system.**"
+    action: ALLOW
+}

--- a/packages/perishable-network/package.json
+++ b/packages/perishable-network/package.json
@@ -1,6 +1,6 @@
 {
   "engines": {
-    "composer": "^0.11.0 || ^0.12.0 || ^0.13.0 "
+    "composer": "^0.14.0"
   },
   "name": "perishable-network",
   "version": "0.1.10",
@@ -34,10 +34,10 @@
   "devDependencies": {
     "browserfs": "^1.2.0",
     "chai": "^3.5.0",
-    "composer-admin": "^0.11.0",
-    "composer-cli": "^0.11.0",
-    "composer-client": "^0.11.0",
-    "composer-connector-embedded": "^0.11.0",
+    "composer-admin": "^0.14.0-0",
+    "composer-cli": "^0.14.0-0",
+    "composer-client": "^0.14.0-0",
+    "composer-connector-embedded": "^0.14.0-0",
     "eslint": "^3.6.1",
     "istanbul": "^0.4.5",
     "jsdoc": "^3.4.1",

--- a/packages/perishable-network/permissions.acl
+++ b/packages/perishable-network/permissions.acl
@@ -16,3 +16,19 @@ rule SystemACL {
   resource: "org.hyperledger.composer.system.**"
   action: ALLOW
 }
+
+rule NetworkAdminUser {
+    description: "Grant business network administrators full access to user resources"
+    participant: "org.hyperledger.composer.system.NetworkAdmin"
+    operation: ALL
+    resource: "**"
+    action: ALLOW
+}
+
+rule NetworkAdminSystem {
+    description: "Grant business network administrators full access to system resources"
+    participant: "org.hyperledger.composer.system.NetworkAdmin"
+    operation: ALL
+    resource: "org.hyperledger.composer.system.**"
+    action: ALLOW
+}

--- a/packages/pii-network/package.json
+++ b/packages/pii-network/package.json
@@ -1,6 +1,6 @@
 {
   "engines": {
-    "composer": "^0.11.0 || ^0.12.0 || ^0.13.0"
+    "composer": "^0.14.0"
   },
   "name": "pii-network",
   "version": "0.1.10",
@@ -33,10 +33,10 @@
   "devDependencies": {
     "browserfs": "^1.2.0",
     "chai": "^3.5.0",
-    "composer-admin": "^0.11.0",
-    "composer-cli": "^0.11.0",
-    "composer-client": "^0.11.0",
-    "composer-connector-embedded": "^0.11.0",
+    "composer-admin": "^0.14.0-0",
+    "composer-cli": "^0.14.0-0",
+    "composer-client": "^0.14.0-0",
+    "composer-connector-embedded": "^0.14.0-0",
     "eslint": "^3.6.1",
     "istanbul": "^0.4.5",
     "jsdoc": "^3.4.1",

--- a/packages/pii-network/permissions.acl
+++ b/packages/pii-network/permissions.acl
@@ -46,3 +46,19 @@ rule SystemACL {
   resource: "org.hyperledger.composer.system.**"
   action: ALLOW
 }
+
+rule NetworkAdminUser {
+    description: "Grant business network administrators full access to user resources"
+    participant: "org.hyperledger.composer.system.NetworkAdmin"
+    operation: ALL
+    resource: "**"
+    action: ALLOW
+}
+
+rule NetworkAdminSystem {
+    description: "Grant business network administrators full access to system resources"
+    participant: "org.hyperledger.composer.system.NetworkAdmin"
+    operation: ALL
+    resource: "org.hyperledger.composer.system.**"
+    action: ALLOW
+}

--- a/packages/trade-network/package.json
+++ b/packages/trade-network/package.json
@@ -1,6 +1,6 @@
 {
   "engines": {
-    "composer": "^0.11.0 || ^0.12.0 || ^0.13.0"
+    "composer": "^0.14.0"
   },
   "name": "trade-network",
   "version": "0.1.10",
@@ -33,10 +33,10 @@
   "devDependencies": {
     "browserfs": "^1.2.0",
     "chai": "^3.5.0",
-    "composer-admin": "^0.11.0",
-    "composer-cli": "^0.11.0",
-    "composer-client": "^0.11.0",
-    "composer-connector-embedded": "^0.11.0",
+    "composer-admin": "^0.14.0-0",
+    "composer-cli": "^0.14.0-0",
+    "composer-client": "^0.14.0-0",
+    "composer-connector-embedded": "^0.14.0-0",
     "eslint": "^3.6.1",
     "istanbul": "^0.4.5",
     "jsdoc": "^3.4.1",

--- a/packages/trade-network/permissions.acl
+++ b/packages/trade-network/permissions.acl
@@ -16,3 +16,19 @@ rule SystemACL {
   resource: "org.hyperledger.composer.system.**"
   action: ALLOW
 }
+
+rule NetworkAdminUser {
+    description: "Grant business network administrators full access to user resources"
+    participant: "org.hyperledger.composer.system.NetworkAdmin"
+    operation: ALL
+    resource: "**"
+    action: ALLOW
+}
+
+rule NetworkAdminSystem {
+    description: "Grant business network administrators full access to system resources"
+    participant: "org.hyperledger.composer.system.NetworkAdmin"
+    operation: ALL
+    resource: "org.hyperledger.composer.system.**"
+    action: ALLOW
+}

--- a/packages/vehicle-lifecycle-network/package.json
+++ b/packages/vehicle-lifecycle-network/package.json
@@ -1,6 +1,6 @@
 {
   "engines": {
-    "composer": "^0.11.0 || ^0.12.0 || ^0.13.0"
+    "composer": "^0.14.0"
   },
   "name": "vehicle-lifecycle-network",
   "version": "0.1.10",
@@ -36,10 +36,10 @@
   "devDependencies": {
     "browserfs": "^1.2.0",
     "chai": "^3.5.0",
-    "composer-admin": "^0.11.0",
-    "composer-cli": "^0.11.0",
-    "composer-client": "^0.11.0",
-    "composer-connector-embedded": "^0.11.0",
+    "composer-admin": "^0.14.0-0",
+    "composer-cli": "^0.14.0-0",
+    "composer-client": "^0.14.0-0",
+    "composer-connector-embedded": "^0.14.0-0",
     "eslint": "^3.6.1",
     "istanbul": "^0.4.5",
     "jsdoc": "^3.4.1",

--- a/packages/vehicle-lifecycle-network/permissions.acl
+++ b/packages/vehicle-lifecycle-network/permissions.acl
@@ -16,3 +16,19 @@ rule SystemACL {
   resource: "org.hyperledger.composer.system.**"
   action: ALLOW
 }
+
+rule NetworkAdminUser {
+    description: "Grant business network administrators full access to user resources"
+    participant: "org.hyperledger.composer.system.NetworkAdmin"
+    operation: ALL
+    resource: "**"
+    action: ALLOW
+}
+
+rule NetworkAdminSystem {
+    description: "Grant business network administrators full access to system resources"
+    participant: "org.hyperledger.composer.system.NetworkAdmin"
+    operation: ALL
+    resource: "org.hyperledger.composer.system.**"
+    action: ALLOW
+}


### PR DESCRIPTION
As a network starter, I can bind an initial set of identities to participants at deployment time #670

Add network admin ACL rules to all of the sample networks, and bump the Composer version to 0.14.0.