### PR TITLE
solution for issue 1500 

### DIFF
--- a/packages/vehicle-lifecycle-network/lib/vda.js
+++ b/packages/vehicle-lifecycle-network/lib/vda.js
@@ -93,19 +93,18 @@ function scrapAllVehiclesByColour(scrapAllVehicles) {
             return query('selectAllCarsByColour', {'colour':scrapAllVehicles.colour});
         })
         .then(function (vehicles) {
-             if (vehicles.length >=1 ) {
-                  var factory = getFactory();
-                  var vehiclesToScrap = vehicles.filter(function(vehicle) {
-                      return vehicle.vehicleStatus !== 'SCRAPPED';
-                 });
-                 for (var x = 0; x < vehiclesToScrap.length; x++) {
-                     vehiclesToScrap[x].vehicleStatus = 'SCRAPPED';
-                     var scrapVehicleEvent = factory.newEvent(NS_D, 'ScrapVehicleEvent');
-                     scrapVehicleEvent.vehicle = vehiclesToScrap[x];
-                     emit(scrapVehicleEvent);
-                 }
-                 return assetRegistry.updateAll(vehiclesToScrap);
+            if (vehicles.length >=1 ) {
+                var factory = getFactory();
+                var vehiclesToScrap = vehicles.filter(function(vehicle) {
+                   return vehicle.vehicleStatus !== 'SCRAPPED';
+                });
+                for (var x = 0; x < vehiclesToScrap.length; x++) {
+                    vehiclesToScrap[x].vehicleStatus = 'SCRAPPED';
+                    var scrapVehicleEvent = factory.newEvent(NS_D, 'ScrapVehicleEvent');
+                    scrapVehicleEvent.vehicle = vehiclesToScrap[x];
+                    emit(scrapVehicleEvent);
+                }
+                return assetRegistry.updateAll(vehiclesToScrap);
              }
         });
-
 }

--- a/packages/vehicle-lifecycle-network/lib/vda.js
+++ b/packages/vehicle-lifecycle-network/lib/vda.js
@@ -100,9 +100,8 @@ function scrapAllVehiclesByColour(scrapAllVehicles) {
                  });
                  for (var x = 0; x < vehiclesToScrap.length; x++) {
                      vehiclesToScrap[x].vehicleStatus = 'SCRAPPED';
-                     vehicles[x].vehicleStatus = 'SCRAPPED';
                      var scrapVehicleEvent = factory.newEvent(NS_D, 'ScrapVehicleEvent');
-                     scrapVehicleEvent.vehicle = vehicles[x];
+                     scrapVehicleEvent.vehicle = vehiclesToScrap[x];
                      emit(scrapVehicleEvent);
                  }
                  return assetRegistry.updateAll(vehiclesToScrap);

--- a/packages/vehicle-lifecycle-network/lib/vda.js
+++ b/packages/vehicle-lifecycle-network/lib/vda.js
@@ -82,43 +82,31 @@ function scrapVehicle(scrapVehicle) {
  * @transaction
  */
 function scrapAllVehiclesByColour(scrapAllVehicles) {
-    console.log('scrapVehicle');
+    console.log('scrapAllVehiclesByColour');
 
     var NS_D = 'org.vda';
     var assetRegistry;
 
-    // create the query
-    var q = {
-        selector: {
-            'vehicleDetails.colour': scrapAllVehicles.colour
-        }
-    };
-
     return getAssetRegistry(NS_D + '.Vehicle')
         .then(function (ar){
             assetRegistry = ar;
-            return queryNative(JSON.stringify(q));
+            return query('selectAllCarsByColour', {'colour':scrapAllVehicles.colour});
         })
-        .then(function (resultArray) {
-            console.log('TP function received query result: ', JSON.stringify(resultArray));
-            if (resultArray.length < 1 ) {
-                throw new Error('No vehicles found with ' + scrapAllVehicles.colour, resultArray.length);
-            }
-
-            var factory = getFactory();
-            var promises =[];
-            var serializer = getSerializer();
-            for (var x = 0; x < resultArray.length; x++) {
-                var currentResult = resultArray[x];
-                var vehicle = serializer.fromJSON(currentResult.Record);
-
-                vehicle.vehicleStatus = 'SCRAPPED';
-                var scrapVehicleEvent = factory.newEvent(NS_D, 'ScrapVehicleEvent');
-                scrapVehicleEvent.vehicle = vehicle;
-                emit(scrapVehicleEvent);
-                promises.push(assetRegistry.update(vehicle));
-
-            }
-            return Promise.all(promises);
+        .then(function (vehicles) {
+             if (vehicles.length >=1 ) {
+                  var factory = getFactory();
+                  var vehiclesToScrap = vehicles.filter(function(vehicle) {
+                      return vehicle.vehicleStatus !== 'SCRAPPED';
+                 });
+                 for (var x = 0; x < vehiclesToScrap.length; x++) {
+                     vehiclesToScrap[x].vehicleStatus = 'SCRAPPED';
+                     vehicles[x].vehicleStatus = 'SCRAPPED';
+                     var scrapVehicleEvent = factory.newEvent(NS_D, 'ScrapVehicleEvent');
+                     scrapVehicleEvent.vehicle = vehicles[x];
+                     emit(scrapVehicleEvent);
+                 }
+                 return assetRegistry.updateAll(vehiclesToScrap);
+             }
         });
+
 }

--- a/packages/vehicle-lifecycle-network/queries.qry
+++ b/packages/vehicle-lifecycle-network/queries.qry
@@ -1,0 +1,6 @@
+query selectAllCarsByColour {
+  description: "Select all cars based on their colour"
+  statement:
+      SELECT org.vda.Vehicle
+          WHERE (vehicleDetails.colour==_$colour)
+}

--- a/packages/vehicle-lifecycle-network/test/vda.js
+++ b/packages/vehicle-lifecycle-network/test/vda.js
@@ -36,7 +36,7 @@ describe('Vehicle Lifecycle Network', function() {
 
     var businessNetworkConnection;
 
-    before(function() {
+    beforeEach(function() {
         BrowserFS.initialize(new BrowserFS.FileSystem.InMemory());
         var adminConnection = new AdminConnection({ fs: bfs_fs });
         return adminConnection.createProfile('defaultProfile', {
@@ -124,4 +124,29 @@ describe('Vehicle Lifecycle Network', function() {
                 });
         });
     });
+
+    describe('ScrapAllVehiclesByColour', function() {
+        it('should select vehicles by colour and change vehicles status to SCRAPPED', function() {
+            /* vehicle with beige colour
+               and id 123456789 resides
+               in reposritory
+            */
+            var vehicleId = '123456789';
+            var scrapVehicleTransaction = factory.newTransaction(NS_D, 'ScrapAllVehiclesByColour');
+            scrapVehicleTransaction.colour = 'Beige';
+            return businessNetworkConnection.submitTransaction(scrapVehicleTransaction)
+                .then(function() {
+                    return businessNetworkConnection.getAssetRegistry(NS_D + '.Vehicle');
+                })
+                .then(function(ar) {
+                    var assetRegistry = ar;
+                    return assetRegistry.get(vehicleId);
+                })
+                .then(function(vehicle) {
+                    vehicle.vehicleStatus.should.equal('SCRAPPED');
+                });
+
+        });
+    });
+
 });


### PR DESCRIPTION
Signed-off-by: shacshar <shacshar@in.ibm.com>

Problem
The issue #1500 deals with the fact that a query in vehicle lifecycle network is not running.

Solution
The query Native is not supported now. The feature of Named Query has been implemented instead. The same is added here in.

https://github.com/hyperledger/composer-sample-networks/pull/95

TestCase
A new testcase has been added to check the functionality of queryNative. The test case select all vehicles by colour (in the test case colour = "Beige") and selected vehicle status is marked "scrapped"