### PR TITLE
add fake timers to enable timestamp advancing

### DIFF
--- a/packages/perishable-network/package.json
+++ b/packages/perishable-network/package.json
@@ -44,7 +44,8 @@
     "license-check": "^1.1.5",
     "mkdirp": "^0.5.1",
     "mocha": "^3.2.0",
-    "moment": "^2.17.1"
+    "moment": "^2.17.1",
+    "sinon": "2.3.8"
   },
   "license-check-config": {
     "src": [


### PR DESCRIPTION
Perishable network was failing tests because it was no longer possible to change the time of a transaction timestamp.

We can (should) use sinon.fakeTimers for that purpose

This PR adds sinon to devDeps, and uses a fake timer to artificially advance the timestamp of a transaction so we can test the contract violation correctly.

Signed-off-by: Nick Lincoln <nkl199@yahoo.co.uk>