### PR TITLE
npm test fails on these samples

### DIFF
--- a/packages/animaltracking-network/package.json
+++ b/packages/animaltracking-network/package.json
@@ -36,7 +36,10 @@
   "devDependencies": {
     "browserfs": "^1.2.0",
     "chai": "^3.5.0",
+    "composer-admin": "^0.14.0-0",
     "composer-cli": "^0.14.0-0",
+    "composer-client": "^0.14.0-0",
+    "composer-common": "^0.14.0-0",
     "composer-connector-embedded": "^0.14.0-0",
     "eslint": "^3.6.1",
     "jsdoc": "^3.5.5",

--- a/packages/digitalproperty-network/package.json
+++ b/packages/digitalproperty-network/package.json
@@ -35,6 +35,7 @@
     "composer-admin": "^0.14.0-0",
     "composer-cli": "^0.14.0-0",
     "composer-client": "^0.14.0-0",
+    "composer-common": "^0.14.0-0",
     "composer-connector-embedded": "^0.14.0-0",
     "eslint": "^3.6.1",
     "istanbul": "^0.4.5",


### PR DESCRIPTION
npm test fails for animaltracking and digitalproperty complaining about not being able to find composer modules.
As they use them directly there is no harm and is right that we should explicitly declare the dependence in package.json

Signed-off-by: Dave Kelsey <d_kelsey@uk.ibm.com>